### PR TITLE
Added support for 'html' in italicize_taxonomy()

### DIFF
--- a/R/italicise_taxonomy.R
+++ b/R/italicise_taxonomy.R
@@ -31,11 +31,11 @@
 #'
 #' According to the binomial nomenclature, the lowest four taxonomic levels (family, genus, species, subspecies) should be printed in italics. This function finds taxonomic names within strings and makes them italic.
 #' @param string a [character] (vector)
-#' @param type type of conversion of the taxonomic names, either "markdown" or "ansi", see *Details*
+#' @param type type of conversion of the taxonomic names, either "markdown", "html" or "ansi", see *Details*
 #' @details
 #' This function finds the taxonomic names and makes them italic based on the [microorganisms] data set.
 #'
-#' The taxonomic names can be italicised using markdown (the default) by adding `*` before and after the taxonomic names, or using ANSI colours by adding `\033[3m` before and `\033[23m` after the taxonomic names. If multiple ANSI colours are not available, no conversion will occur.
+#' The taxonomic names can be italicised using markdown (the default) by adding `*` before and after the taxonomic names, or `<i>` and `</i>` when using html. When using 'ansi', ANSI colours will be added using `\033[3m` before and `\033[23m` after the taxonomic names. If multiple ANSI colours are not available, no conversion will occur.
 #'
 #' This function also supports abbreviation of the genus if it is followed by a species, such as "E. coli" and "K. pneumoniae ozaenae".
 #' @export
@@ -44,18 +44,21 @@
 #' italicise_taxonomy("An overview of S. aureus isolates")
 #'
 #' cat(italicise_taxonomy("An overview of S. aureus isolates", type = "ansi"))
-italicise_taxonomy <- function(string, type = c("markdown", "ansi")) {
+italicise_taxonomy <- function(string, type = c("markdown", "ansi", "html")) {
   if (missing(type)) {
     type <- "markdown"
   }
   meet_criteria(string, allow_class = "character")
-  meet_criteria(type, allow_class = "character", has_length = 1, is_in = c("markdown", "ansi"))
+  meet_criteria(type, allow_class = "character", has_length = 1, is_in = c("markdown", "ansi", "html"))
 
   add_MO_lookup_to_AMR_env()
 
   if (type == "markdown") {
     before <- "*"
     after <- "*"
+  } else if (type == "html") {
+    before <- "<i>"
+    after <- "</i>"
   } else if (type == "ansi") {
     if (!has_colour() && !identical(Sys.getenv("IN_PKGDOWN"), "true")) {
       return(string)
@@ -134,7 +137,7 @@ italicise_taxonomy <- function(string, type = c("markdown", "ansi")) {
 
 #' @rdname italicise_taxonomy
 #' @export
-italicize_taxonomy <- function(string, type = c("markdown", "ansi")) {
+italicize_taxonomy <- function(string, type = c("markdown", "ansi", "html")) {
   if (missing(type)) {
     type <- "markdown"
   }

--- a/inst/tinytest/test-italicise_taxonomy.R
+++ b/inst/tinytest/test-italicise_taxonomy.R
@@ -41,3 +41,7 @@ if (AMR:::has_colour()) {
     "test for \033[3mE. coli\033[23m"
   )
 }
+expect_identical(
+  italicise_taxonomy("test for E. coli", "html"),
+  "test for <i>E. coli</i>"
+)

--- a/man/italicise_taxonomy.Rd
+++ b/man/italicise_taxonomy.Rd
@@ -5,14 +5,14 @@
 \alias{italicize_taxonomy}
 \title{Italicise Taxonomic Families, Genera, Species, Subspecies}
 \usage{
-italicise_taxonomy(string, type = c("markdown", "ansi"))
+italicise_taxonomy(string, type = c("markdown", "ansi", "html"))
 
-italicize_taxonomy(string, type = c("markdown", "ansi"))
+italicize_taxonomy(string, type = c("markdown", "ansi", "html"))
 }
 \arguments{
 \item{string}{a \link{character} (vector)}
 
-\item{type}{type of conversion of the taxonomic names, either "markdown" or "ansi", see \emph{Details}}
+\item{type}{type of conversion of the taxonomic names, either "markdown", "html" or "ansi", see \emph{Details}}
 }
 \description{
 According to the binomial nomenclature, the lowest four taxonomic levels (family, genus, species, subspecies) should be printed in italics. This function finds taxonomic names within strings and makes them italic.
@@ -20,7 +20,7 @@ According to the binomial nomenclature, the lowest four taxonomic levels (family
 \details{
 This function finds the taxonomic names and makes them italic based on the \link{microorganisms} data set.
 
-The taxonomic names can be italicised using markdown (the default) by adding \code{*} before and after the taxonomic names, or using ANSI colours by adding \verb{\\033[3m} before and \verb{\\033[23m} after the taxonomic names. If multiple ANSI colours are not available, no conversion will occur.
+The taxonomic names can be italicised using markdown (the default) by adding \code{*} before and after the taxonomic names, or \verb{<i>} and \verb{</i>} when using html. When using 'ansi', ANSI colours will be added using \verb{\\033[3m} before and \verb{\\033[23m} after the taxonomic names. If multiple ANSI colours are not available, no conversion will occur.
 
 This function also supports abbreviation of the genus if it is followed by a species, such as "E. coli" and "K. pneumoniae ozaenae".
 }


### PR DESCRIPTION
First of all - Thanks for providing this great package! 👍 

This small PR adds support for `"html"` as a valid type in `italicize_taxonomy()` as well as updates the relevant tinytest and roxy documentation.

I find it particularly useful to have the option of html output in the context producing html reports with knitr.
