### PR TITLE
Document Python installation channels and enforce_method in AMR for Python vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: AMR
-Version: 3.0.1.9075
+Version: 3.0.1.9076
 Date: 2026-06-26
 Title: Antimicrobial Resistance Data Analysis
 Description: Functions to simplify and standardise antimicrobial resistance (AMR)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# AMR 3.0.1.9075
+# AMR 3.0.1.9076
 
 Planned as v3.1.0, end of June 2026.
 
@@ -51,6 +51,7 @@ Planned as v3.1.0, end of June 2026.
 * Improved console messages with clickable links throughout, powered by `cli` if it is installed (#191, #265)
 * `as.disk()`: input validation is now more strict, rejecting values that are not recognisable as a numeric disk zone diameter
 * `as.sir()` gains an `enforce_method` argument (`"auto"`, `"mic"`, or `"disk"`) to force the interpretation method when S3 class information is lost, e.g. when called from Python (#291)
+* `AMR for Python` vignette: added sections on installation channels (stable CRAN vs. development GitHub via `AMR.beta`) and on using `enforce_method` in `as_sir()` from Python
 
 # AMR 3.0.1
 

--- a/vignettes/AMR_for_Python.Rmd
+++ b/vignettes/AMR_for_Python.Rmd
@@ -200,6 +200,48 @@ AMR.antimicrobials
 | ZFD | NaN         | Zoliflodacin         | None                       | NaN      | None       | NaN    | None     |
 
 
+# Installation Channels
+
+## Stable Release (CRAN)
+
+The default `AMR` Python package uses the latest stable version of the `AMR` R package, published on CRAN. After running `pip install AMR`, import it as usual:
+
+```python
+import AMR
+
+AMR.example_isolates
+```
+
+## Development Version (GitHub)
+
+To use the latest development version of the `AMR` R package (sourced directly from GitHub), import the `beta` sub-package and alias it as `AMR`:
+
+```python
+import AMR.beta as AMR
+
+AMR.example_isolates
+```
+
+Aliasing with `as AMR` keeps all downstream code identical to the stable import. Switching between the stable release and the development version requires changing only the import line — nothing else in your script needs to change.
+
+# SIR Classification with `as_sir()`
+
+## Using `enforce_method`
+
+The `as_sir()` function in R uses S3 method dispatch to select the correct calculation method based on the input class: `<mic>` for MIC values and `<disk>` for disk diffusion values. Because Python objects do not carry R class attributes through the `rpy2` bridge, this automatic dispatch may not resolve correctly.
+
+To explicitly specify the input type, use the `enforce_method` argument:
+
+```python
+# Treat the column as MIC values — maps to R's as.sir.mic()
+AMR.as_sir(df["MIC_col"], mo="E. coli", ab="AMX", guideline="EUCAST", enforce_method="mic")
+
+# Treat the column as disk diffusion values — maps to R's as.sir.disk()
+AMR.as_sir(df["disk_col"], mo="E. coli", ab="AMX", guideline="EUCAST", enforce_method="disk")
+```
+
+Without `enforce_method`, R falls back to class-based dispatch on the raw Python input, which may fail or return unexpected results. Always supply `enforce_method` when calling `as_sir()` from Python.
+
 # Conclusion
 
 With the `AMR` Python package, Python users can now effortlessly call R functions from the `AMR` R package. This eliminates the need for complex `rpy2` configurations and provides a clean, easy-to-use interface for antimicrobial resistance analysis. The examples provided above demonstrate how this can be applied to typical workflows, such as standardising microorganism and antimicrobial names or calculating resistance.


### PR DESCRIPTION
## Summary

- Adds a new **Installation Channels** section to `vignettes/AMR_for_Python.Rmd` explaining the stable CRAN release (`import AMR`) vs. the development GitHub version (`import AMR.beta as AMR`), including the key point that aliasing keeps all downstream code identical
- Adds a new **SIR Classification with `as_sir()`** section documenting the `enforce_method` argument, explaining why S3 dispatch fails through the `rpy2` bridge and how to pass `enforce_method="mic"` / `enforce_method="disk"` explicitly
- Bumps version to 3.0.1.9076 and adds a `NEWS.md` entry

## Test plan

- [ ] Verify rendered Rmd output looks correct (section headings, code blocks, prose)
- [ ] Confirm no existing content was altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197jkepcq3nHptcCNeaVQc5

---
_Generated by [Claude Code](https://claude.ai/code/session_0197jkepcq3nHptcCNeaVQc5)_