### PR TITLE
fix: normalise year-qualified AMR_guideline option in all affected functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: AMR
-Version: 3.0.1.9077
-Date: 2026-06-26
+Version: 3.0.1.9078
+Date: 2026-06-27
 Title: Antimicrobial Resistance Data Analysis
 Description: Functions to simplify and standardise antimicrobial resistance (AMR)
   data analysis and to work with microbial and antimicrobial properties by

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# AMR 3.0.1.9077
+# AMR 3.0.1.9078
 
 Planned as v3.1.0, end of June 2026.
 
@@ -20,6 +20,7 @@ Planned as v3.1.0, end of June 2026.
 * New `wisca_plot()` to assess the susceptibility and incidence distributions from the Monte Carlo simulations
 
 ### Fixed
+* Setting `options(AMR_guideline = "EUCAST 2012")` or any year-qualified value no longer causes errors or silent wrong behaviour in `interpretive_rules()`, `resistance()`, `susceptibility()`, `count_resistant()`, `count_susceptible()`, and SIR plotting/printing functions (#298)
 * `as.sir()`
   * On data frames: already-converted SIR columns no longer dropped on re-run (#278)
   * Metadata columns (e.g. `patient`, `ward`) no longer misidentified as antibiotic columns

--- a/R/count.R
+++ b/R/count.R
@@ -126,6 +126,11 @@ count_resistant <- function(...,
                             only_all_tested = FALSE,
                             guideline = getOption("AMR_guideline", "EUCAST")) {
   # other arguments for meet_criteria are handled by sir_calc()
+  if (guideline %like% "EUCAST") {
+    guideline <- "EUCAST"
+  } else if (guideline %like% "CLSI") {
+    guideline <- "CLSI"
+  }
   meet_criteria(guideline, allow_class = "character", is_in = c("EUCAST", "CLSI"), has_length = 1)
   if (is.null(getOption("AMR_guideline")) && missing(guideline) && message_not_thrown_before("count_resistant", "eucast_default", entire_session = TRUE)) {
     message_("{.help [{.fun count_resistant}](AMR::count_resistant)} assumes the EUCAST guideline and thus considers the 'I' category susceptible. Set the {.arg guideline} argument or the {.code AMR_guideline} option to either \"CLSI\" or \"EUCAST\", see {.topic [AMR-options](AMR::AMR-options)}.")
@@ -150,6 +155,11 @@ count_susceptible <- function(...,
                               only_all_tested = FALSE,
                               guideline = getOption("AMR_guideline", "EUCAST")) {
   # other arguments for meet_criteria are handled by sir_calc()
+  if (guideline %like% "EUCAST") {
+    guideline <- "EUCAST"
+  } else if (guideline %like% "CLSI") {
+    guideline <- "CLSI"
+  }
   meet_criteria(guideline, allow_class = "character", is_in = c("EUCAST", "CLSI"), has_length = 1)
   if (is.null(getOption("AMR_guideline")) && missing(guideline) && message_not_thrown_before("count_susceptible", "eucast_default", entire_session = TRUE)) {
     message_("{.help [{.fun count_susceptible}](AMR::count_susceptible)} assumes the EUCAST guideline and thus considers the 'I' category susceptible. Set the {.arg guideline} argument or the {.code AMR_guideline} option to either \"CLSI\" or \"EUCAST\", see {.topic [AMR-options](AMR::AMR-options)}.")

--- a/R/interpretive_rules.R
+++ b/R/interpretive_rules.R
@@ -175,6 +175,11 @@ interpretive_rules <- function(x,
                                ...) {
   meet_criteria(x, allow_class = "data.frame")
   meet_criteria(col_mo, allow_class = "character", has_length = 1, is_in = colnames(x), allow_NULL = TRUE)
+  if (guideline %like% "EUCAST") {
+    guideline <- "EUCAST"
+  } else if (guideline %like% "CLSI") {
+    guideline <- "CLSI"
+  }
   meet_criteria(guideline, allow_class = "character", has_length = 1, is_in = c("EUCAST", "CLSI"))
   meet_criteria(info, allow_class = "logical", has_length = 1)
   meet_criteria(rules, allow_class = "character", has_length = c(1, 2, 3, 4, 5, 6), is_in = c("breakpoints", "expected_phenotypes", "expert", "other", "all", "custom"))
@@ -199,12 +204,6 @@ interpretive_rules <- function(x,
   )
 
   add_MO_lookup_to_AMR_env()
-
-  if (guideline %like% "EUCAST") {
-    guideline <- "EUCAST"
-  } else if (guideline %like% "CLSI") {
-    guideline <- "CLSI"
-  }
 
   if ("custom" %in% rules && is.null(custom_rules)) {
     warning_("in {.help [{.fun interpretive_rules}](AMR::interpretive_rules)}: no custom rules were set with the {.arg custom_rules} argument",

--- a/R/plotting.R
+++ b/R/plotting.R
@@ -482,7 +482,7 @@ scale_x_sir <- function(colours_SIR = c(
                           R = "#ED553B"
                         ),
                         language = get_AMR_locale(),
-                        eucast_I = getOption("AMR_guideline", "EUCAST") == "EUCAST",
+                        eucast_I = getOption("AMR_guideline", "EUCAST") %like% "EUCAST",
                         ...) {
   meet_criteria(colours_SIR, allow_class = "character", has_length = c(1, 3, 4))
   language <- validate_language(language)
@@ -499,7 +499,7 @@ scale_colour_sir <- function(colours_SIR = c(
                                R = "#ED553B"
                              ),
                              language = get_AMR_locale(),
-                             eucast_I = getOption("AMR_guideline", "EUCAST") == "EUCAST",
+                             eucast_I = getOption("AMR_guideline", "EUCAST") %like% "EUCAST",
                              ...) {
   meet_criteria(colours_SIR, allow_class = "character", has_length = c(1, 3, 4))
   language <- validate_language(language)
@@ -528,7 +528,7 @@ scale_fill_sir <- function(colours_SIR = c(
                              R = "#ED553B"
                            ),
                            language = get_AMR_locale(),
-                           eucast_I = getOption("AMR_guideline", "EUCAST") == "EUCAST",
+                           eucast_I = getOption("AMR_guideline", "EUCAST") %like% "EUCAST",
                            ...) {
   meet_criteria(colours_SIR, allow_class = "character", has_length = c(1, 3, 4))
   language <- validate_language(language)

--- a/R/proportion.R
+++ b/R/proportion.R
@@ -236,6 +236,11 @@ resistance <- function(...,
                        only_all_tested = FALSE,
                        guideline = getOption("AMR_guideline", "EUCAST")) {
   # other arguments for meet_criteria are handled by sir_calc()
+  if (guideline %like% "EUCAST") {
+    guideline <- "EUCAST"
+  } else if (guideline %like% "CLSI") {
+    guideline <- "CLSI"
+  }
   meet_criteria(guideline, allow_class = "character", is_in = c("EUCAST", "CLSI"), has_length = 1)
   if (is.null(getOption("AMR_guideline")) && missing(guideline) && message_not_thrown_before("resistance", "eucast_default", entire_session = TRUE)) {
     message_("{.help [{.fun resistance}](AMR::resistance)} assumes the EUCAST guideline and thus considers the 'I' category susceptible. Set the {.arg guideline} argument or the {.code AMR_guideline} option to either \"CLSI\" or \"EUCAST\", see {.topic [AMR-options](AMR::AMR-options)}.")
@@ -264,6 +269,11 @@ susceptibility <- function(...,
                            only_all_tested = FALSE,
                            guideline = getOption("AMR_guideline", "EUCAST")) {
   # other arguments for meet_criteria are handled by sir_calc()
+  if (guideline %like% "EUCAST") {
+    guideline <- "EUCAST"
+  } else if (guideline %like% "CLSI") {
+    guideline <- "CLSI"
+  }
   meet_criteria(guideline, allow_class = "character", is_in = c("EUCAST", "CLSI"), has_length = 1)
   if (is.null(getOption("AMR_guideline")) && missing(guideline) && message_not_thrown_before("susceptibility", "eucast_default", entire_session = TRUE)) {
     message_("{.help [{.fun susceptibility}](AMR::susceptibility)} assumes the EUCAST guideline and thus considers the 'I' category susceptible. Set the {.arg guideline} argument or the {.code AMR_guideline} option to either \"CLSI\" or \"EUCAST\", see {.topic [AMR-options](AMR::AMR-options)}.")

--- a/R/sir.R
+++ b/R/sir.R
@@ -2119,7 +2119,7 @@ pillar_shaft.sir <- function(x, ...) {
     out[is.na(x)] <- pillar::style_subtle("  NA")
     out[x == "S"] <- font_green_bg("  S  ") # has font_black internally
     out[x == "SDD"] <- font_green_lighter_bg(" SDD ") # has font_black internally
-    if (getOption("AMR_guideline", "EUCAST")[1] == "EUCAST") {
+    if (getOption("AMR_guideline", "EUCAST")[1] %like% "EUCAST") {
       out[x == "I"] <- font_green_lighter_bg("  I  ") # has font_black internally
     } else {
       out[x == "I"] <- font_orange_bg("  I  ") # has font_black internally


### PR DESCRIPTION
Fixes #298

Setting `options(AMR_guideline = "EUCAST 2012")` or `"CLSI 2023"` (year-qualified values) previously broke several functions. This PR resolves all affected locations.

## Hard errors fixed

`meet_criteria(..., is_in = c("EUCAST", "CLSI"))` rejected year-qualified values. A `%like%` normalisation step is now applied before the validation in:

- `interpretive_rules()` — moved the existing normalisation block above `meet_criteria`; removed the now-redundant duplicate
- `resistance()` and `susceptibility()` (`proportion.R`)
- `count_resistant()` and `count_susceptible()` (`count.R`)

## Silent wrong behaviour fixed

`== "EUCAST"` comparisons evaluated to `FALSE` for `"EUCAST 2012"`, incorrectly switching EUCAST-style I-colouring to CLSI-style:

- `scale_x_sir()`, `scale_colour_sir()`, `scale_fill_sir()` (`plotting.R`) — `eucast_I` defaults
- `print.sir()` (`sir.R`) — terminal I-value colouring

All `== "EUCAST"` comparisons replaced with `%like% "EUCAST"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0169LucQ7SHDLHdTnDs1ENhd)_